### PR TITLE
Added './pkg-build.sh make' for running 'make' with R etc. setup

### DIFF
--- a/pkg-build.sh
+++ b/pkg-build.sh
@@ -264,6 +264,10 @@ RunScript() {
     Rscript "$@"
 }
 
+RunMake() {
+    make "$@"
+}
+
 RunBuild() {
     >&2 echo "Building with: R CMD build ${R_BUILD_ARGS}"
     R CMD build ${R_BUILD_ARGS} .
@@ -409,6 +413,12 @@ case $COMMAND in
     ## Run an R script
     "run_script")
 	RunScript "$@"
+	;;
+
+    ##
+    ## Run make
+    "make")
+	RunMake "$@"
 	;;
 
     ##


### PR DESCRIPTION
This pull request adds `./pkg-build.sh make` support such that `make` will see the setup (PATHs, environment variables, ...) that `pkg-build.sh` provides.

I have a `Makefile` in the root directory for several of my R packages that provides `make build`, `make check`, `make spell` and so on, so this addition helps be deploy that also under CI.  Also, I'm not only using `pkg-build.sh`(*) to build and check R packages, but also for other types of R processing.  Most recently, I'm building and deploying websites in R (based on RSP-embedded Markdown).  Locally I have a `Makefile` for this, and with this addition I can reuse that as-is on Travis CI.

(*) BTW, maybe `pkg-build.sh` should be renamed to reflect the fact that you can use it to get access to an R environment, not just for "build":ing R package.  What about calling it `r-env.sh`.