### PR TITLE
BUG FIX: 'dump_logs_by_extension out' would also dump *.Rout files

### DIFF
--- a/pkg-build.sh
+++ b/pkg-build.sh
@@ -247,7 +247,7 @@ DumpLogsByExtension() {
         >&2 echo "Could not find package Rcheck directory, skipping log dump."
         exit 0
     fi
-    for name in $(find "${package}" -type f -name "*${extension}"); do
+    for name in $(find "${package}" -type f -name "*.${extension}"); do
         echo ">>> Filename: ${name} <<<"
         cat ${name}
     done

--- a/pkg-build.sh
+++ b/pkg-build.sh
@@ -235,22 +235,30 @@ DumpSysinfo() {
     R -e '.libPaths(); options(width = 90) ; devtools::session_info(); installed.packages()'
 }
 
+DumpByPattern() {
+    if [[ -z "$1" ]]; then
+        >&2 echo "dump_by_pattern requires exactly one argument, got: $@"
+        exit 1
+    fi
+    pattern=$1
+    shift
+    package=$(find . -maxdepth 1 -name "*.Rcheck" -type d)
+    if [[ ${#package[@]} -ne 1 ]]; then
+        >&2 echo "Could not find package Rcheck directory, skipping dump."
+        exit 0
+    fi
+    for name in $(find "${package}" -type f -name "${pattern}"); do
+        echo ">>> Filename: ${name} <<<"
+        cat ${name}
+    done
+}
+
 DumpLogsByExtension() {
     if [[ -z "$1" ]]; then
         >&2 echo "dump_logs_by_extension requires exactly one argument, got: $@"
         exit 1
     fi
-    extension=$1
-    shift
-    package=$(find . -maxdepth 1 -name "*.Rcheck" -type d)
-    if [[ ${#package[@]} -ne 1 ]]; then
-        >&2 echo "Could not find package Rcheck directory, skipping log dump."
-        exit 0
-    fi
-    for name in $(find "${package}" -type f -name "*.${extension}"); do
-        echo ">>> Filename: ${name} <<<"
-        cat ${name}
-    done
+    DumpByPattern "*.$1"
 }
 
 DumpLogs() {

--- a/pkg-build.sh
+++ b/pkg-build.sh
@@ -416,6 +416,11 @@ case $COMMAND in
     "dump_logs_by_extension")
         DumpLogsByExtension "$@"
         ;;
+    ##
+    ## Dump selected files by filename pattern
+    "dump_by_pattern")
+        DumpByPattern "$@"
+        ;;
 
     ##
     ## Run an R script


### PR DESCRIPTION
I ended up getting ["This log is too long to be displayed. Please reduce the verbosity of your build or download the raw log."](https://travis-ci.org/HenrikBengtsson/matrixStats/builds/47803485) (see end of page) from Travis.  This was because `dump_logs_by_extension out` would also dump *.Rout files, e.g.

```
$ find ./matrixStats.Rcheck -type f -name '*out'
./matrixStats.Rcheck/00install.out
./matrixStats.Rcheck/matrixStats-Ex.Rout
./matrixStats.Rcheck/tests/allocArray.Rout
[...]
```
Note that this would also cause `dump_logs` to output all *.Rout files.