### PR TITLE
Install specific package version from CRAN

### DIFF
--- a/pkg-build.sh
+++ b/pkg-build.sh
@@ -397,7 +397,7 @@ case $COMMAND in
         ;;
     ##
     ## Install a specific version of an R dependency from CRAN 
-    "r_install_version")
+    "r_install_version"|"install_r_version")
         RInstallVersion "$@"
         ;;
     ##

--- a/pkg-build.sh
+++ b/pkg-build.sh
@@ -220,6 +220,16 @@ RInstall() {
     Rscript -e 'install.packages(commandArgs(TRUE), repos="'"${CRAN}"'")' "$@"
 }
 
+RInstallVersion() {
+    EnsureDevtools
+    if [[ "" == "$*" ]]; then
+        >&2 echo "No arguments to r_install_version"
+        exit 1
+    fi
+    >&2 echo "Installing R package(s): $@"
+    Rscript -e 'library(devtools); library(methods); install_version(commandArgs(TRUE)[1], commandArgs(TRUE)[2], repos="'"${CRAN}"'")' "$@"
+}
+
 BiocInstall() {
     if [[ "" == "$*" ]]; then
         >&2 echo "No arguments to bioc_install"
@@ -384,6 +394,11 @@ case $COMMAND in
     ## Install an R dependency from CRAN
     "install_r"|"r_install")
         RInstall "$@"
+        ;;
+    ##
+    ## Install a specific version of an R dependency from CRAN 
+    "r_install_version")
+        RInstallVersion "$@"
         ;;
     ##
     ## Install an R dependency from Bioconductor


### PR DESCRIPTION
Hi,

this adds a new function RInstallVerision() to pkg-build.sh. It allows to install a specific version of a package by
./pkg-build.sh r_install_version packageName packageVersion

Here's a working example from the recent travis check of my repo
https://travis-ci.org/bleutner/RStoolbox/jobs/78993897
